### PR TITLE
Update FrequencyCap and FrequencyPeriodInMinutes [#104903408]

### DIFF
--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -100,6 +100,12 @@ module Ttdrest
         if !params[:frequency_pricing_slope].nil?
           rtb_ad_group_data = rtb_ad_group_data.merge({"FrequencyPricingSlope" => params[:frequency_pricing_slope]})
         end
+        if !params[:frequency_period_in_minutes].nil?
+          rtb_ad_group_data = rtb_ad_group_data.merge({"FrequencyPeriodInMinutes" => params[:frequency_period_in_minutes]})
+        end
+        if !params[:frequency_cap].nil?
+          rtb_ad_group_data = rtb_ad_group_data.merge({"FrequencyCap" => params[:frequency_cap]})
+        end
         if !params[:site_list_ids].nil?
           rtb_ad_group_data = rtb_ad_group_data.merge({"SiteListIds" => params[:site_list_ids]})
         end


### PR DESCRIPTION
@ericrvass This is a PR for a change to the ttdrest gem to allow setting of frequency cap. I tested by modifying my local copy of the gem and inspecting the data before the request, and checking in the trade desk.

I was not able to pull in the most recent commits in the ttdrest to my fork for some reason, may need some help on that!

![image](https://cloud.githubusercontent.com/assets/3085393/10789765/b18f0bcc-7d55-11e5-83b5-ad631b39bbdf.png)
