### PR TITLE
Add support for Flash Creatives [Finishes #107231234]

### DIFF
--- a/lib/ttdrest/concerns/creative.rb
+++ b/lib/ttdrest/concerns/creative.rb
@@ -164,8 +164,31 @@ module Ttdrest
         result = data_put(path, content_type, creative_data.to_json)
         return result
       end
-      
-      #TODO: Flash Creatives
+
+      def create_flash_creative(name, flash_content, clickthrough_url, landing_page_url, options = {})
+        advertiser_id = self.advertiser_id || options[:advertiser_id]
+        path = "/creative"
+        content_type = 'application/json'
+        creative_data = {
+          "AdvertiserId" => advertiser_id,
+          "CreativeName" => name
+        }
+        params = options[:params] || {}
+        if !params[:right_media_offer_type_id].nil?
+          creative_data = creative_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+        end
+
+        flash_data = {
+          "FlashContent" => flash_content,
+          "ClickthroughUrl" => clickthrough_url,
+          "LandingPageUrl" => landing_page_url,
+          "FlashClickTrackingParameterName" => "clickTAG" # TODO: figure out what to actually use here
+        }
+
+        creative_data = creative_data.merge({"FlashAttributes" => flash_data})
+        result = data_post(path, content_type, creative_data.to_json)
+        return result
+      end
       
       #TODO: 3rd Party HTML Creatives
       

--- a/lib/ttdrest/concerns/creative.rb
+++ b/lib/ttdrest/concerns/creative.rb
@@ -191,9 +191,41 @@ module Ttdrest
       end
       
       #TODO: 3rd Party HTML Creatives
-      
-      #TODO: Video Creatives
-      
+
+      def create_video_creative(name, video_content, clickthrough_url, landing_page_url, options = {})
+        advertiser_id = self.advertiser_id || options[:advertiser_id]
+        path = "/creative"
+        content_type = 'application/json'
+        creative_data = {
+          "AdvertiserId" => advertiser_id,
+          "CreativeName" => name
+          }
+        params = options[:params] || {}
+        if !params[:description].nil?
+          creative_data = creative_data.merge({"Description" => params[:description]})
+        end
+        if !params[:third_party_impression_tracking_url].nil?
+          creative_data = creative_data.merge({"ThirdPartyImpressionTrackingUrl" => params[:third_party_impression_tracking_url]})
+        end
+        if !params[:right_media_offer_type_id].nil?
+          creative_data = creative_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+        end
+        if !params[:ad_technology_ids].nil?
+          creative_data = creative_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
+        end
+
+        video_data = {
+          "VideoContent" => video_content,
+          "ClickthroughUrl" => clickthrough_url,
+          "LandingPageUrl" => landing_page_url
+          }
+
+        creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})
+
+        result = data_post(path, content_type, creative_data.to_json)
+        return result
+      end
+
     end
   end
 end


### PR DESCRIPTION
@ericrvass this is ready for review. Any thoughts on what to put for the "FlashClickTrackingParameterName" field? Here is a relevant excerpt from the documentation:

The click tracking parameter used in the flash file. This is typically clickTAG or some variant, but the parameter is case-sensitive, so clickTAG is different from ClickTAG and clickTag. Once uploaded, if you are not able to click through this creative successfully, it may be because this value is not set correctly. If you do not know what the correct parameter name is and none of the standard variants work, please contact your creative team.

https://api.thetradedesk.com/v2/doc/api/post-creative
