### PR TITLE
Changed html5 height and width to correct capitalized letters

### DIFF
--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -80,8 +80,8 @@ module Ttdrest
             "ZipArchiveContent" => html_zip_content,
             "ClickthroughUrl" => clickthrough_url,
             "LandingPageUrls" => [landing_page_url],
-            "width" => width,
-            "height" => height,
+            "Width" => width,
+            "Height" => height,
             "ClickTrackingParameterName" => click_tracking_parameter_name
           }
 


### PR DESCRIPTION
@ericrvass this change is necessary for html creatives to be uploaded correctly to the trade desk.
