### PR TITLE
Add global update for all creative types

### DIFF
--- a/lib/ttdrest/concerns/creative.rb
+++ b/lib/ttdrest/concerns/creative.rb
@@ -28,6 +28,7 @@ module Ttdrest
       end
 
       def update_creative(creative_data:)
+        binding.pry
         data_put(
           path = "/creative",
           content_type = 'application/json',

--- a/lib/ttdrest/concerns/creative.rb
+++ b/lib/ttdrest/concerns/creative.rb
@@ -27,7 +27,13 @@ module Ttdrest
         return result
       end
 
-      #TODO: 3rd Party HTML Creatives
+      def update_creative(creative_data:)
+        data_put(
+          path = "/creative",
+          content_type = 'application/json',
+          creative_data
+        )
+      end
 
     end
   end

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -40,42 +40,42 @@ module Ttdrest
         end
 
         def update_image_creative(creative_id, name, image_content, clickthrough_url, landing_page_url, options = {})
-           advertiser_id = self.advertiser_id || options[:advertiser_id]
-           path = "/creative"
-           content_type = 'application/json'
-           creative_data = {
-             "CreativeId" => creative_id,
-             "AdvertiserId" => advertiser_id,
-             "CreativeName" => name
-           }
-           params = options[:params] || {}
-           if !params[:description].nil?
-             creative_data = creative_data.merge({"Description" => params[:description]})
-           end
+          advertiser_id = self.advertiser_id || options[:advertiser_id]
+          path = "/creative"
+          content_type = 'application/json'
+          creative_data = {
+           "CreativeId" => creative_id,
+           "AdvertiserId" => advertiser_id,
+           "CreativeName" => name
+          }
+          params = options[:params] || {}
+          if !params[:description].nil?
+           creative_data = creative_data.merge({"Description" => params[:description]})
+          end
 
-           image_data = {
-             "ClickthroughUrl" => clickthrough_url,
-             "LandingPageUrl" => landing_page_url
-           }
+          image_data = {
+           "ClickthroughUrl" => clickthrough_url,
+           "LandingPageUrl" => landing_page_url
+          }
 
-           if !params[:right_media_offer_type_id].nil?
-             image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
-           end
-           if !params[:ad_technology_ids].nil?
-             image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
-           end
-           if !params[:is_securable].nil?
-             image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
-           end
-           if !image_content.blank?
-             image_data = image_data.merge({"ImageContent" => image_content})
-           end
+          if !params[:right_media_offer_type_id].nil?
+           image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+          end
+          if !params[:ad_technology_ids].nil?
+           image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
+          end
+          if !params[:is_securable].nil?
+           image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
+          end
+          if !image_content.blank?
+           image_data = image_data.merge({"ImageContent" => image_content})
+          end
 
-           creative_data = creative_data.merge({"ImageAttributes" => image_data})
+          creative_data = creative_data.merge({"ImageAttributes" => image_data})
 
-           result = data_put(path, content_type, creative_data.to_json)
-           return result
-         end
+          result = data_put(path, content_type, creative_data.to_json)
+          return result
+        end
       end
     end
   end

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -39,6 +39,43 @@ module Ttdrest
           return result
         end
 
+        def update_image_creative(creative_id, name, image_content, clickthrough_url, landing_page_url, options = {})
+           advertiser_id = self.advertiser_id || options[:advertiser_id]
+           path = "/creative"
+           content_type = 'application/json'
+           creative_data = {
+             "CreativeId" => creative_id,
+             "AdvertiserId" => advertiser_id,
+             "CreativeName" => name
+           }
+           params = options[:params] || {}
+           if !params[:description].nil?
+             creative_data = creative_data.merge({"Description" => params[:description]})
+           end
+
+           image_data = {
+             "ClickthroughUrl" => clickthrough_url,
+             "LandingPageUrl" => landing_page_url
+           }
+
+           if !params[:right_media_offer_type_id].nil?
+             image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+           end
+           if !params[:ad_technology_ids].nil?
+             image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
+           end
+           if !params[:is_securable].nil?
+             image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
+           end
+           if !image_content.blank?
+             image_data = image_data.merge({"ImageContent" => image_content})
+           end
+
+           creative_data = creative_data.merge({"ImageAttributes" => image_data})
+
+           result = data_put(path, content_type, creative_data.to_json)
+           return result
+         end
       end
     end
   end

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -39,43 +39,6 @@ module Ttdrest
           return result
         end
 
-        def update_image_creative(creative_id, name, image_content, clickthrough_url, landing_page_url, options = {})
-          advertiser_id = self.advertiser_id || options[:advertiser_id]
-          path = "/creative"
-          content_type = 'application/json'
-          creative_data = {
-            "CreativeId" => creative_id,
-            "AdvertiserId" => advertiser_id,
-            "CreativeName" => name
-          }
-          params = options[:params] || {}
-          if !params[:description].nil?
-            creative_data = creative_data.merge({"Description" => params[:description]})
-          end
-
-          image_data = {
-            "ClickthroughUrl" => clickthrough_url,
-            "LandingPageUrl" => landing_page_url
-          }
-
-          if !params[:right_media_offer_type_id].nil?
-            image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
-          end
-          if !params[:ad_technology_ids].nil?
-            image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
-          end
-          if !params[:is_securable].nil?
-            image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
-          end
-          if !image_content.blank?
-            image_data = image_data.merge({"ImageContent" => image_content})
-          end
-
-          creative_data = creative_data.merge({"ImageAttributes" => image_data})
-
-          result = data_put(path, content_type, creative_data.to_json)
-          return result
-        end
       end
     end
   end

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -44,31 +44,31 @@ module Ttdrest
           path = "/creative"
           content_type = 'application/json'
           creative_data = {
-           "CreativeId" => creative_id,
-           "AdvertiserId" => advertiser_id,
-           "CreativeName" => name
+            "CreativeId" => creative_id,
+            "AdvertiserId" => advertiser_id,
+            "CreativeName" => name
           }
           params = options[:params] || {}
           if !params[:description].nil?
-           creative_data = creative_data.merge({"Description" => params[:description]})
+            creative_data = creative_data.merge({"Description" => params[:description]})
           end
 
           image_data = {
-           "ClickthroughUrl" => clickthrough_url,
-           "LandingPageUrl" => landing_page_url
+            "ClickthroughUrl" => clickthrough_url,
+            "LandingPageUrl" => landing_page_url
           }
 
           if !params[:right_media_offer_type_id].nil?
-           image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+            image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
           if !params[:ad_technology_ids].nil?
-           image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
+            image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
           end
           if !params[:is_securable].nil?
-           image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
+            image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
           end
           if !image_content.blank?
-           image_data = image_data.merge({"ImageContent" => image_content})
+            image_data = image_data.merge({"ImageContent" => image_content})
           end
 
           creative_data = creative_data.merge({"ImageAttributes" => image_data})

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.24"
+  VERSION = "0.0.26"
 end


### PR DESCRIPTION
This removes update_image_creative out of the image type and up to creative.rb under a global method to update any type of creative.