### PR TITLE
Support additional megagon migration fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :development, :test do
   gem 'rspec'
   gem 'webmock'
   gem 'vcr'
+  gem 'pry'
 end

--- a/lib/ttdrest/client.rb
+++ b/lib/ttdrest/client.rb
@@ -3,6 +3,7 @@ require "ttdrest/concerns/ad_group"
 require "ttdrest/concerns/advertiser"
 require "ttdrest/concerns/audience"
 require "ttdrest/concerns/campaign"
+require "ttdrest/concerns/campaign_flight"
 require "ttdrest/concerns/creative"
 require "ttdrest/concerns/data_group"
 require "ttdrest/concerns/dmp"
@@ -19,6 +20,7 @@ module Ttdrest
     include Ttdrest::Concerns::Advertiser
     include Ttdrest::Concerns::Audience
     include Ttdrest::Concerns::Campaign
+    include Ttdrest::Concerns::CampaignFlight
     include Ttdrest::Concerns::Creative
     include Ttdrest::Concerns::DataGroup
     include Ttdrest::Concerns::Dmp

--- a/lib/ttdrest/client.rb
+++ b/lib/ttdrest/client.rb
@@ -1,5 +1,6 @@
 require "ttdrest/concerns/base"
 require "ttdrest/concerns/ad_group"
+require 'ttdrest/concerns/additional_fees'
 require "ttdrest/concerns/advertiser"
 require "ttdrest/concerns/audience"
 require "ttdrest/concerns/campaign"
@@ -17,6 +18,7 @@ module Ttdrest
   class Client
     include Ttdrest::Concerns::Base
     include Ttdrest::Concerns::AdGroup
+    include Ttdrest::Concerns::AdditionalFees
     include Ttdrest::Concerns::Advertiser
     include Ttdrest::Concerns::Audience
     include Ttdrest::Concerns::Campaign

--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -57,7 +57,7 @@ module Ttdrest
         if !name.nil?
           ad_group_data = ad_group_data.merge({"AdGroupName" => name})
         end
-        
+
         ad_group_data['IsClassic'] = true 
 
         if !params[:description].nil?
@@ -147,6 +147,8 @@ module Ttdrest
           ad_group_data["IsEnabled"] = params[:is_enabled] unless params[:is_enabled].nil?
           ad_group_data["IndustryCategoryId"] = params[:industry_category_id] unless params[:industry_category_id].nil? 
           ad_group_data['IsClassic'] = false
+
+          ad_group_data['AssociatedBidLists'] = params[:associated_bid_lists] unless params[:associated_bid_lists].nil?
 
           {}.tap do |rtb_ad_group_data|
             rtb_ad_group_data["BudgetSettings"] = budget_settings unless budget_settings.nil?

--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -156,6 +156,7 @@ module Ttdrest
             rtb_ad_group_data["BaseBidCPM"] = base_bid_cpm unless base_bid_cpm.nil?
             rtb_ad_group_data["MaxBidCPM"] = max_bid_cpm unless max_bid_cpm.nil?
             rtb_ad_group_data["CreativeIds"] = creative_ids unless creative_ids.empty?
+            rtb_ad_group_data['QualityAllianceViewabilityTargeting'] = params[:quality_alliance_viewability_targeting] unless params[:quality_alliance_viewability_targeting].nil?
 
             unless params[:audience_id].nil?
               {}.tap do |audience_data|

--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -150,6 +150,7 @@ module Ttdrest
 
           ad_group_data['AssociatedBidLists'] = params[:associated_bid_lists] unless params[:associated_bid_lists].nil?
           ad_group_data['NewBidLists'] = params[:new_bid_lists] unless params[:new_bid_lists].nil?
+          ad_group_data['PredictiveClearingEnabled'] = params[:predictive_clearing] unless params[:predictive_clearing].nil?
 
           {}.tap do |rtb_ad_group_data|
             rtb_ad_group_data["BudgetSettings"] = budget_settings unless budget_settings.nil?
@@ -157,6 +158,9 @@ module Ttdrest
             rtb_ad_group_data["MaxBidCPM"] = max_bid_cpm unless max_bid_cpm.nil?
             rtb_ad_group_data["CreativeIds"] = creative_ids unless creative_ids.empty?
             rtb_ad_group_data['QualityAllianceViewabilityTargeting'] = params[:quality_alliance_viewability_targeting] unless params[:quality_alliance_viewability_targeting].nil?
+            rtb_ad_group_data["ContractTargeting"] = params[:contract_targeting] unless params[:contract_targeting].nil?
+            rtb_ad_group_data["ROIGoal"] = params[:roi_goal] unless params[:roi_goal].nil?
+            rtb_ad_group_data["DimensionalBiddingAutoOptimizationSettings"] = params[:dimensional_bidding_auto_optimization_settings] unless params[:dimensional_bidding_auto_optimization_settings].nil?
 
             unless params[:audience_id].nil?
               {}.tap do |audience_data|

--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -49,6 +49,13 @@ module Ttdrest
         if !name.nil?
           ad_group_data = ad_group_data.merge({"AdGroupName" => name})
         end
+
+        if params[:is_classic].nil? || params[:is_classic]
+          ad_group_data['IsClassic'] = true
+        else
+          ad_group_data['IsClassic'] = false
+        end
+
         if !params[:description].nil?
           ad_group_data = ad_group_data.merge({"Description" => params[:description]})
         end

--- a/lib/ttdrest/concerns/ad_group.rb
+++ b/lib/ttdrest/concerns/ad_group.rb
@@ -149,6 +149,7 @@ module Ttdrest
           ad_group_data['IsClassic'] = false
 
           ad_group_data['AssociatedBidLists'] = params[:associated_bid_lists] unless params[:associated_bid_lists].nil?
+          ad_group_data['NewBidLists'] = params[:new_bid_lists] unless params[:new_bid_lists].nil?
 
           {}.tap do |rtb_ad_group_data|
             rtb_ad_group_data["BudgetSettings"] = budget_settings unless budget_settings.nil?

--- a/lib/ttdrest/concerns/additional_fees.rb
+++ b/lib/ttdrest/concerns/additional_fees.rb
@@ -4,19 +4,34 @@
 module Ttdrest
   module Concerns
     module AdditionalFees
-      # There is no "updating" existing fees, only creating new ones with a start_date as soon as possible.
+      def get_additional_fees(owner_id, owner_type)
+        path = "/additional_fees/#{owner_type}/#{owner_id}"
+        get(path, {})
+      end
+
+      def update_additional_fees(owner_id, owner_type, start_date, fees)
+        path = '/additionalfees'
+        content_type = 'application/json'
+        body = additional_fees_body(owner_id, owner_type, start_date, fees)
+
+        data_put(path, content_type, body.to_json) 
+      end
+
       def create_additional_fees(owner_id, owner_type, start_date, fees)
         path = '/additionalfees'
-        context_type = 'application/json'
+        content_type = 'application/json'
+        body = additional_fees_body(owner_id, owner_type, start_date, fees)
 
-        additional_fees_body = {
+        data_post(path, content_type, additional_fees_body.to_json)
+      end
+
+      def additional_fees_body(owner_id, owner_type, start_date, fees)
+        {
           'StartDateUtc' => start_date.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
           'OwnerId' => owner_id,
           'OwnerType' => owner_type,
           'Fees' => parse_fees(fees),
         }
-
-        data_post(path, context_type, additional_fees_body.to_json)
       end
 
       def parse_fees(fees)

--- a/lib/ttdrest/concerns/additional_fees.rb
+++ b/lib/ttdrest/concerns/additional_fees.rb
@@ -1,0 +1,34 @@
+# Built against TTD Api documentation
+# https://api.thetradedesk.com/v3/portal/api/ref/post-additionalfees
+
+module Ttdrest
+  module Concerns
+    module AdditionalFee
+      # There is no "updating" existing fees, only creating new ones with a start_date as soon as possible.
+      def create_additional_fees(owner_id, owner_type, start_date, fees)
+        path = '/additionalfees'
+        context_type = 'application/json'
+
+        additional_fees_body = {
+          'StartDateUtc' => start_date.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+          'OwnerId' = owner_id,
+          'OwnerType' => owner_typem
+          'Fees' => parse_fees(fees),
+        }
+
+        data_post(path, context_type, additional_fees_body.to_json)
+      end
+
+      def parse_fees(fees)
+        # Allowing ruby symbol use and naming
+        fees.map do |fee|
+          {
+            'Description' => (fee[:description] || fee['Description']),
+            'Amount' => (fee[:amount] || fee['Amount']),
+            'FeeType' => (fee[:fee_type] || fee['FeeType']),
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/ttdrest/concerns/additional_fees.rb
+++ b/lib/ttdrest/concerns/additional_fees.rb
@@ -3,7 +3,7 @@
 
 module Ttdrest
   module Concerns
-    module AdditionalFee
+    module AdditionalFees
       # There is no "updating" existing fees, only creating new ones with a start_date as soon as possible.
       def create_additional_fees(owner_id, owner_type, start_date, fees)
         path = '/additionalfees'
@@ -11,8 +11,8 @@ module Ttdrest
 
         additional_fees_body = {
           'StartDateUtc' => start_date.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
-          'OwnerId' = owner_id,
-          'OwnerType' => owner_typem
+          'OwnerId' => owner_id,
+          'OwnerType' => owner_type,
           'Fees' => parse_fees(fees),
         }
 

--- a/lib/ttdrest/concerns/additional_fees.rb
+++ b/lib/ttdrest/concerns/additional_fees.rb
@@ -5,7 +5,7 @@ module Ttdrest
   module Concerns
     module AdditionalFees
       def get_additional_fees(owner_id, owner_type)
-        path = "/additional_fees/#{owner_type}/#{owner_id}"
+        path = "/additionalfees/#{owner_type}/#{owner_id}"
         get(path, {})
       end
 
@@ -22,7 +22,7 @@ module Ttdrest
         content_type = 'application/json'
         body = additional_fees_body(owner_id, owner_type, start_date, fees)
 
-        data_post(path, content_type, additional_fees_body.to_json)
+        data_post(path, content_type, body.to_json)
       end
 
       def additional_fees_body(owner_id, owner_type, start_date, fees)

--- a/lib/ttdrest/concerns/base.rb
+++ b/lib/ttdrest/concerns/base.rb
@@ -1,5 +1,15 @@
+require 'date'
+require 'active_support/notifications'
+
 module Ttdrest
   class AuthorizationFailedError < StandardError; end
+  class RecoverableHttpError < StandardError
+    def initialize(message = nil, data = {})
+      super(message)
+
+      @data = data
+    end
+  end
 
   module Concerns
     module Base
@@ -8,6 +18,8 @@ module Ttdrest
 
       VERSION = "v3"
       RETRIES = 2
+      ERROR_RETRIES = 3
+      MAXIMUM_WAIT_TIME = 120
 
       def authenticate(options = {})
         client_id = self.client_login || options[:client_login]
@@ -20,7 +32,60 @@ module Ttdrest
       def check_response(response)
         if response.code.eql?("403")
           raise AuthorizationFailedError
+        elsif retryable_http_error?(response)
+          raise RecoverableHttpError.new('', response)
         end
+      end
+
+      def retryable_http_error?(response)
+        response && (
+          response.code == 429 || (500..599).include?(response.code)
+        )
+      end
+
+      def parse_header_retry(response)
+        return nil unless response && response['Retry-After']
+
+        if response['Retry-After'] =~ /^\d+$/
+          response['Retry-After'].to_i
+        else
+          date = Time.rfc2822(response['Retry-After'])
+          wait_time = date.to_i - Time.now.to_i
+          return nil unless wait_time.positive?
+          wait_time > MAXIMUM_WAIT_TIME ? MAXIMUM_WAIT_TIME :  wait_time
+        end
+      rescue ArgumentError
+        nil
+      end
+
+      def perform_request(request, connection = http_connection)
+        retries = 0
+        response = nil
+
+        begin
+          ActiveSupport::Notifications.instrument('ttd.request') do |payload|
+            payload[:request] = request
+            payload[:retries] = retries
+
+            response = connection.request(request)
+            payload[:response] = response
+          end
+
+          check_response(response)
+        rescue RecoverableHttpError, SocketError
+          raise if retries >= ERROR_RETRIES
+          retries += 1
+
+          if sleep_time = parse_header_retry(response)
+            sleep(sleep_time)
+          else
+            sleep((1.25 ** retries) * 1 - (0.3 * rand))
+          end
+
+          retry
+        end
+
+        response
       end
 
       def get(path, params)
@@ -28,8 +93,7 @@ module Ttdrest
         begin
           request = Net::HTTP::Get.new(params.blank? ? "/#{VERSION}#{path}" : "/#{VERSION}#{path}?".concat(params.collect { |k,v| "#{k}=#{CGI::escape(v.to_s)}" }.join('&')))
           request['TTD-Auth'] = self.auth_token
-          response = http_connection.request(request)
-          check_response(response)
+          response = perform_request(request)
           result = response.body.blank? ? "" : JSON.parse(response.body)
           return result
         rescue AuthorizationFailedError
@@ -49,8 +113,7 @@ module Ttdrest
           request = Net::HTTP::Post.new("/#{VERSION}#{path}", initheader = {'Content-Type' => content_type})
           request['TTD-Auth'] = self.auth_token
           request.body = json_data
-          response = http_connection.request(request)
-          check_response(response)
+          response = perform_request(request)
           result = response.body.blank? ? "" : JSON.parse(response.body)
           return result
         rescue AuthorizationFailedError
@@ -70,8 +133,7 @@ module Ttdrest
           request = Net::HTTP::Put.new("/#{VERSION}#{path}", initheader = {'Content-Type' => content_type})
           request['TTD-Auth'] = self.auth_token
           request.body = json_data
-          response = http_connection.request(request)
-          check_response(response)
+          response = perform_request(request)
           result = response.body.blank? ? "" : JSON.parse(response.body)
           return result
         rescue AuthorizationFailedError

--- a/lib/ttdrest/concerns/base.rb
+++ b/lib/ttdrest/concerns/base.rb
@@ -39,7 +39,7 @@ module Ttdrest
 
       def retryable_http_error?(response)
         response && (
-          response.code == 429 || (500..599).include?(response.code)
+          response.code == '429' || (500..599).include?(response.code.to_i)
         )
       end
 

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -51,7 +51,7 @@ module Ttdrest
         end
 
         # On create only, support passing in additional_fee_card
-        if campaign_id.nil? && !params[:additional_fee_card].nil?
+        if !campaign_id.present? && !params[:additional_fee_card].nil?
           campaign_data['AdditionalFeeCardOnCreate'] = params[:additional_fee_card]
         end
 

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -79,7 +79,7 @@ module Ttdrest
         end
 
         if params[:campaign_flights].present?
-          campaign_data = campaign_data.merge({"CampaignFlights" => params[:campaign_flights]})
+          campaign_data = campaign_data.merge({ "CampaignFlights" => params[:campaign_flights] })
         end
 
         # Accepts a date

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -78,10 +78,6 @@ module Ttdrest
           campaign_data = campaign_data.merge({"DailyBudgetInImpressions" => params[:daily_budget_in_impressions]})
         end
 
-        if params[:campaign_flights].present?
-          campaign_data = campaign_data.merge({ "CampaignFlights" => params[:campaign_flights] })
-        end
-
         # Accepts a date
         # nil
         # or, if we're not sending the key, nothing (no update)

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -50,6 +50,11 @@ module Ttdrest
           campaign_data.delete("CampaignConversionReportingColumns") if campaign_conversion_reporting_columns.empty?
         end
 
+        # On create only, support passing in additional_fee_card
+        if campaign_id.nil? && !params[:additional_fee_card].nil?
+          campaign_data['AdditionalFeeCardOnCreate'] = params[:additional_fee_card]
+        end
+
         if !name.blank?
           campaign_data = campaign_data.merge({"CampaignName" => name})
         end

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -53,38 +53,52 @@ module Ttdrest
         if !name.blank?
           campaign_data = campaign_data.merge({"CampaignName" => name})
         end
+
         if !budget.nil?
           campaign_data = campaign_data.merge({"Budget" => budget})
         end
+
         if !start_date.nil?
           campaign_data = campaign_data.merge({"StartDate" => start_date.strftime("%Y-%m-%dT%H:%M:%SZ")})
         end
+
         if !params[:description].nil?
           campaign_data = campaign_data.merge({"Description" => params[:description]})
         end
+
         if !params[:budget_in_impressions].nil?
           campaign_data = campaign_data.merge({"BudgetInImpressions" => params[:budget_in_impressions]})
         end
+
         if !params[:daily_budget].nil?
           campaign_data = campaign_data.merge({"DailyBudget" => params[:daily_budget]})
         end
+
         if !params[:daily_budget_in_impressions].nil?
           campaign_data = campaign_data.merge({"DailyBudgetInImpressions" => params[:daily_budget_in_impressions]})
         end
-        if !params[:end_date].nil?
+
+        # Accepts a date
+        # nil
+        # or, if we're not sending the key, nothing (no update)
+        if params.key?(:end_date) && !params[:end_date].nil?
           campaign_data = campaign_data.merge({"EndDate" => params[:end_date].strftime("%Y-%m-%dT%H:%M:%SZ")})
-        else
+        elsif params.key?(:end_date)
           campaign_data = campaign_data.merge({"EndDate" => nil})
         end
+
         if !params[:availability].nil?
           campaign_data = campaign_data.merge({"Availability" => availability})
         end
+
         if !params[:partner_cost_percentage_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCostPercentageFee" => params[:partner_cost_percentage_fee]})
         end
+
         if !params[:partner_cpm_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCPMFee" => params[:partner_cpm_fee]})
         end
+
         if !params[:partner_cpc_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCPCFee" => params[:partner_cpc_fee]})
         end

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -51,7 +51,7 @@ module Ttdrest
         end
 
         # On create only, support passing in additional_fee_card
-        if !campaign_id.present? && !params[:additional_fee_card].nil?
+        if !campaign_id.present? && params[:additional_fee_card].present?
           campaign_data['AdditionalFeeCardOnCreate'] = params[:additional_fee_card]
         end
 

--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -78,6 +78,10 @@ module Ttdrest
           campaign_data = campaign_data.merge({"DailyBudgetInImpressions" => params[:daily_budget_in_impressions]})
         end
 
+        if params[:campaign_flights].present?
+          campaign_data = campaign_data.merge({"CampaignFlights" => params[:campaign_flights]})
+        end
+
         # Accepts a date
         # nil
         # or, if we're not sending the key, nothing (no update)

--- a/lib/ttdrest/concerns/campaign_flight.rb
+++ b/lib/ttdrest/concerns/campaign_flight.rb
@@ -12,7 +12,8 @@ module Ttdrest
             'StartDateInclusiveUTC' => start_date,
             'EndDateExclusiveUTC' => end_date
           }
-          return data_put("/campaignflight", 'application/json', flight_data.to_json)
+          result = data_put("/campaignflight", 'application/json', flight_data.to_json)
+          return result
         end
       end
     end

--- a/lib/ttdrest/concerns/campaign_flight.rb
+++ b/lib/ttdrest/concerns/campaign_flight.rb
@@ -9,9 +9,9 @@ module Ttdrest
             'DailyTargetInAdvertiserCurrency' => daily_budget,
             'CampaignId' => campaign_id,
             'CampaignFlightId' => campaign_flight_id,
-            'StartDateInclusiveUTC' => start_date,
-            'EndDateExclusiveUTC' => end_date
+            'EndDateExclusiveUTC' => end_date,
           }
+          flight_data["StartDateInclusiveUTC"] = start_date if start_date.present?
           result = data_put("/campaignflight", 'application/json', flight_data.to_json)
           return result
         end

--- a/lib/ttdrest/concerns/campaign_flight.rb
+++ b/lib/ttdrest/concerns/campaign_flight.rb
@@ -2,7 +2,7 @@ module Ttdrest
   module Concerns
     module CampaignFlight
 
-      def update_campaign_flight(campaign_id, campaign_flight_id, budget, daily_budget, start_date, end_date)
+      def update_campaign_flight(campaign_id:, campaign_flight_id:, budget:, daily_budget:, start_date:, end_date:)
         if campaign_id && campaign_flight_id
           flight_data = {
             'BudgetInAdvertiserCurrency' => budget,

--- a/lib/ttdrest/concerns/campaign_flight.rb
+++ b/lib/ttdrest/concerns/campaign_flight.rb
@@ -1,0 +1,20 @@
+module Ttdrest
+  module Concerns
+    module CampaignFlight
+
+      def update_campaign_flight(campaign_id, campaign_flight_id, budget, daily_budget, start_date, end_date)
+        if campaign_id && campaign_flight_id
+          flight_data = {
+            'BudgetInAdvertiserCurrency' => budget,
+            'DailyTargetInAdvertiserCurrency' => daily_budget,
+            'CampaignId' => campaign_id,
+            'CampaignFlightId' => campaign_flight_id,
+            'StartDateInclusiveUTC' => start_date,
+            'EndDateExclusiveUTC' => end_date
+          }
+          return data_put("/campaignflight", 'application/json', flight_data.to_json)
+        end
+      end
+    end
+  end
+end

--- a/lib/ttdrest/concerns/creative_types/flash.rb
+++ b/lib/ttdrest/concerns/creative_types/flash.rb
@@ -27,11 +27,6 @@ module Ttdrest
           end
 
           if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
             flash_data = flash_data.merge({
               ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
             })

--- a/lib/ttdrest/concerns/creative_types/flash.rb
+++ b/lib/ttdrest/concerns/creative_types/flash.rb
@@ -26,6 +26,17 @@ module Ttdrest
             flash_data = flash_data.merge({"IsSecurable" => params[:is_securable]})
           end
 
+          if !params[:third_party_tracking_tags].nil?
+            creative_data = creative_data.merge({
+              ImageAttributes: {
+                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              }
+            })
+            flash_data = flash_data.merge({
+              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+            })
+          end
+
           creative_data = creative_data.merge({"FlashAttributes" => flash_data})
           result = data_post(path, content_type, creative_data.to_json)
           return result

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -91,15 +91,9 @@ module Ttdrest
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-
           if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
             details = details.merge({
-              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              "ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ]
             })
           end
 

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -91,7 +91,6 @@ module Ttdrest
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-          creative_data = creative_data.merge({"Html5Attributes" => details})
 
           if !params[:third_party_tracking_tags].nil?
             creative_data = creative_data.merge({
@@ -99,7 +98,12 @@ module Ttdrest
                 ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
               }
             })
+            details = details.merge({
+              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+            })
           end
+
+          creative_data = creative_data.merge({"Html5Attributes" => details})
 
           data_post(path, content_type, creative_data.to_json)
 

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -87,13 +87,13 @@ module Ttdrest
             "UseClickthroughAsDefault" => true
           }
 
-          if params[:right_media_offer_type_id].present?
+          if !params[:right_media_offer_type_id].nil?
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
           creative_data = creative_data.merge({"Html5Attributes" => details})
 
-          if params[:third_party_tracking_tags].present?
+          if !params[:third_party_tracking_tags].nil?
             creative_data = creative_data.merge({
               ImageAttributes: {
                 ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -87,8 +87,12 @@ module Ttdrest
             "UseClickthroughAsDefault" => true
           }
 
-          if !params[:right_media_offer_type_id].nil?
+          if params[:right_media_offer_type_id].present?
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
+          end
+
+          if params[:third_party_tracking_tags].present?
+            details = details.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
           end
 
           creative_data = creative_data.merge({"Html5Attributes" => details})

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -91,11 +91,15 @@ module Ttdrest
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-          if params[:third_party_tracking_tags].present?
-            details = details.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
-          end
-
           creative_data = creative_data.merge({"Html5Attributes" => details})
+
+          if params[:third_party_tracking_tags].present?
+            creative_data = creative_data.merge({
+              ImageAttributes: {
+                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              }
+            })
+          end
 
           data_post(path, content_type, creative_data.to_json)
 

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -21,16 +21,20 @@ module Ttdrest
             "LandingPageUrl" => landing_page_url
           }
 
-          if !params[:right_media_offer_type_id].nil?
+          if params[:right_media_offer_type_id].present?
             image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-          if !params[:ad_technology_ids].nil?
+          if params[:ad_technology_ids].present?
             image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
           end
 
-          if !params[:is_securable].nil?
+          if params[:is_securable].present?
             image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
+          end
+
+          if params[:third_party_tracking_tags].present?
+            image_data = image_data.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
           end
 
           creative_data = creative_data.merge({"ImageAttributes" => image_data})

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -21,19 +21,19 @@ module Ttdrest
             "LandingPageUrl" => landing_page_url
           }
 
-          if params[:right_media_offer_type_id].present?
+          if !params[:right_media_offer_type_id].nil?
             image_data = image_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-          if params[:ad_technology_ids].present?
+          if !params[:ad_technology_ids].nil?
             image_data = image_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
           end
 
-          if params[:is_securable].present?
+          if !params[:is_securable].nil?
             image_data = image_data.merge({"IsSecurable" => params[:is_securable]})
           end
 
-          if params[:third_party_tracking_tags].present?
+          if !params[:third_party_tracking_tags].nil?
             image_data = image_data.merge({
               ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ] 
             })

--- a/lib/ttdrest/concerns/creative_types/image.rb
+++ b/lib/ttdrest/concerns/creative_types/image.rb
@@ -34,7 +34,9 @@ module Ttdrest
           end
 
           if params[:third_party_tracking_tags].present?
-            image_data = image_data.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
+            image_data = image_data.merge({
+              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ] 
+            })
           end
 
           creative_data = creative_data.merge({"ImageAttributes" => image_data})

--- a/lib/ttdrest/concerns/creative_types/video.rb
+++ b/lib/ttdrest/concerns/creative_types/video.rb
@@ -30,11 +30,16 @@ module Ttdrest
           if params[:is_securable].present?
             video_data = video_data.merge({"IsSecurable" => params[:is_securable]})
           end
-          if params[:third_party_tracking_tags].present?
-            video_data = video_data.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
-          end
 
           creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})
+
+          if params[:third_party_tracking_tags].present?
+            creative_data = creative_data.merge({
+              ImageAttributes: {
+                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              }
+            })
+          end
 
           result = data_post(path, content_type, creative_data.to_json)
           return result

--- a/lib/ttdrest/concerns/creative_types/video.rb
+++ b/lib/ttdrest/concerns/creative_types/video.rb
@@ -33,14 +33,6 @@ module Ttdrest
 
           creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})
 
-          if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
-          end
-
           result = data_post(path, content_type, creative_data.to_json)
           return result
         end

--- a/lib/ttdrest/concerns/creative_types/video.rb
+++ b/lib/ttdrest/concerns/creative_types/video.rb
@@ -21,14 +21,17 @@ module Ttdrest
             "LandingPageUrl" => landing_page_url
           }
 
-          if !params[:right_media_offer_type_id].nil?
+          if params[:right_media_offer_type_id].present?
             video_data = video_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
-          if !params[:ad_technology_ids].nil?
+          if params[:ad_technology_ids].present?
             video_data = video_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
           end
-          if !params[:is_securable].nil?
+          if params[:is_securable].present?
             video_data = video_data.merge({"IsSecurable" => params[:is_securable]})
+          end
+          if params[:third_party_tracking_tags].present?
+            video_data = video_data.merge({"ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ] })
           end
 
           creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})

--- a/lib/ttdrest/concerns/creative_types/video.rb
+++ b/lib/ttdrest/concerns/creative_types/video.rb
@@ -21,19 +21,19 @@ module Ttdrest
             "LandingPageUrl" => landing_page_url
           }
 
-          if params[:right_media_offer_type_id].present?
+          if !params[:right_media_offer_type_id].nil?
             video_data = video_data.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
-          if params[:ad_technology_ids].present?
+          if !params[:ad_technology_ids].nil?
             video_data = video_data.merge({"AdTechnologyIds" => params[:ad_technology_ids]})
           end
-          if params[:is_securable].present?
+          if !params[:is_securable].nil?
             video_data = video_data.merge({"IsSecurable" => params[:is_securable]})
           end
 
           creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})
 
-          if params[:third_party_tracking_tags].present?
+          if !params[:third_party_tracking_tags].nil?
             creative_data = creative_data.merge({
               ImageAttributes: {
                 ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]

--- a/lib/ttdrest/concerns/hd_reports.rb
+++ b/lib/ttdrest/concerns/hd_reports.rb
@@ -1,15 +1,22 @@
+# frozen_string_literal: true
+
+# Provides API for getting HDReports
+# Documented https://api.thetradedesk.com/v3/doc/api/post-myreports-reportexecution-query-advertisers
+
 module Ttdrest
   module Concerns
     module HdReports
 
       def get_reports(report_date, options = {})
         advertiser_id = self.advertiser_id || options[:advertiser_id]
-        path = "/hdreports"
+        path = '/hdreports'
         content_type = 'application/json'
-        report_data = {
-          "AdvertiserId" => advertiser_id,
-          "ReportDateUTC" => report_date.strftime("%Y-%m-%d")
-        }
+        report_data = {}.tap do |search_params|
+          search_params['AdvertiserId"'] = advertiser_id
+          search_params['ReportDateUTC'] = report_date.strftime("%Y-%m-%d")
+          search_params['Type'] = options[:type] if options[:type]
+          search_params['Duration'] = options[:duration] if options[:duration]
+        end
 
         result = data_post(path, content_type, report_data.to_json)
         return result

--- a/lib/ttdrest/concerns/hd_reports.rb
+++ b/lib/ttdrest/concerns/hd_reports.rb
@@ -10,18 +10,15 @@ module Ttdrest
       def get_reports(report_date, options = {})
         advertiser_id = self.advertiser_id || options[:advertiser_id]
         path = '/hdreports'
-        content_type = 'application/json'
         report_data = {}.tap do |search_params|
-          search_params['AdvertiserId"'] = advertiser_id
+          search_params['AdvertiserId'] = advertiser_id
           search_params['ReportDateUTC'] = report_date.strftime("%Y-%m-%d")
           search_params['Type'] = options[:type] if options[:type]
           search_params['Duration'] = options[:duration] if options[:duration]
         end
 
-        result = data_post(path, content_type, report_data.to_json)
-        return result
+        data_post(path, 'application/json', report_data.to_json)
       end
-
     end
   end
 end

--- a/lib/ttdrest/concerns/my_reports.rb
+++ b/lib/ttdrest/concerns/my_reports.rb
@@ -1,22 +1,28 @@
+# frozen_string_literal: true
+
+# Provides API for getting MyReports
+# Documented https://api.thetradedesk.com/v3/doc/api/post-myreports
+
 module Ttdrest
   module Concerns
     module MyReports
 
       def get_my_reports(report_date, options = {})
         advertiser_id = self.advertiser_id || options[:advertiser_id]
-        path = "/myreports/reportexecution/query/advertisers"
+        path = '/myreports/reportexecution/query/advertisers'
         content_type = 'application/json'
-        report_data = {
-          "AdvertiserIds" => [advertiser_id],
-          "ExecutionSpansStartDate" => options[:execution_spans_start_date].present? ? options[:execution_spans_start_date] : report_date.strftime("%Y-%m-%dT00:00:00.0000000+00:00"),
-          "ExecutionSpansEndDate" => options[:execution_spans_end_date].present? ? options[:execution_spans_end_date] : (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00"),
-          "PageStartIndex" => options[:page].present? ? options[:page] : 0,
-          "PageSize" => 1,
-          "ExecutionStates" => options[:execution_states].present? ? options[:execution_states] : ["Complete"]
-        }
-        if options[:sort_fields].present?
-          report_data["SortFields"] = options[:sort_fields]
+        report_data = {}.tap do |search_params|
+          search_params['AdvertiserIds'] = [advertiser_id]
+          search_params['ReportDateUTC'] = report_date.strftime("%Y-%m-%d")
+          search_params['ReportScheduleNameContains'] = options[:report_schedule_name_contains] if options[:report_schedule_name_contains]
+          search_params['ExecutionStates'] = options[:execution_states].present? ? options[:execution_states] : ["Complete"]
+          search_params['ExecutionSpansStartDate'] = options[:execution_spans_start_date].present? ? options[:execution_spans_start_date] : report_date.strftime("%Y-%m-%dT00:00:00.0000000+00:00")
+          search_params['ExecutionSpansEndDate'] = options[:execution_spans_end_date].present? ? options[:execution_spans_end_date] : (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00")
+          search_params['PageStartIndex'] = options[:page].present? ? options[:page] : 0
+          search_params['PageSize'] = options[:page_size].present? ? options[:page_size] : 1
+          search_params['SortFields'] = options[:sort_fields] if options[:sort_fields]
         end
+
         result = data_post(path, content_type, report_data.to_json)
         return result
       end

--- a/lib/ttdrest/concerns/my_reports.rb
+++ b/lib/ttdrest/concerns/my_reports.rb
@@ -10,23 +10,28 @@ module Ttdrest
       def get_my_reports(report_date, options = {})
         advertiser_id = self.advertiser_id || options[:advertiser_id]
         path = '/myreports/reportexecution/query/advertisers'
-        content_type = 'application/json'
         report_data = {}.tap do |search_params|
           search_params['AdvertiserIds'] = [advertiser_id]
           search_params['ReportDateUTC'] = report_date.strftime("%Y-%m-%d")
           search_params['ReportScheduleNameContains'] = options[:report_schedule_name_contains] if options[:report_schedule_name_contains]
-          search_params['ExecutionStates'] = options[:execution_states].present? ? options[:execution_states] : ["Complete"]
-          search_params['ExecutionSpansStartDate'] = options[:execution_spans_start_date].present? ? options[:execution_spans_start_date] : report_date.strftime("%Y-%m-%dT00:00:00.0000000+00:00")
-          search_params['ExecutionSpansEndDate'] = options[:execution_spans_end_date].present? ? options[:execution_spans_end_date] : (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00")
-          search_params['PageStartIndex'] = options[:page].present? ? options[:page] : 0
-          search_params['PageSize'] = options[:page_size].present? ? options[:page_size] : 1
+          search_params['ExecutionStates'] = present_or_default(options[:execution_states],["Complete"])
+          search_params['ExecutionSpansStartDate'] = present_or_default(options[:execution_spans_start_date], report_date.strftime("%Y-%m-%dT00:00:00.0000000+00:00"))
+          search_params['ExecutionSpansEndDate'] = present_or_default([:execution_spans_end_date], (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00"))
+          search_params['PageStartIndex'] = present_or_default(options[:page], 0)
+          search_params['PageSize'] = present_or_default(options[:page_size],1)
           search_params['SortFields'] = options[:sort_fields] if options[:sort_fields]
         end
 
-        result = data_post(path, content_type, report_data.to_json)
-        return result
+        data_post(path, 'application/json', report_data.to_json)
       end
 
+      def present_or_default(value, default)
+        if value.present?
+          value
+        else
+          default
+        end
+      end
     end
   end
 end

--- a/lib/ttdrest/concerns/my_reports.rb
+++ b/lib/ttdrest/concerns/my_reports.rb
@@ -16,7 +16,7 @@ module Ttdrest
           search_params['ReportScheduleNameContains'] = options[:report_schedule_name_contains] if options[:report_schedule_name_contains]
           search_params['ExecutionStates'] = present_or_default(options[:execution_states],["Complete"])
           search_params['ExecutionSpansStartDate'] = present_or_default(options[:execution_spans_start_date], report_date.strftime("%Y-%m-%dT00:00:00.0000000+00:00"))
-          search_params['ExecutionSpansEndDate'] = present_or_default([:execution_spans_end_date], (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00"))
+          search_params['ExecutionSpansEndDate'] = present_or_default(options[:execution_spans_end_date], (report_date + 1.day).strftime("%Y-%m-%dT00:00:00.0000000+00:00"))
           search_params['PageStartIndex'] = present_or_default(options[:page], 0)
           search_params['PageSize'] = present_or_default(options[:page_size],1)
           search_params['SortFields'] = options[:sort_fields] if options[:sort_fields]

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.29"
+  VERSION = "0.0.30"
 end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.30"
+  VERSION = "0.0.31"
 end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.31"
+  VERSION = "0.0.32"
 end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.32"
+  VERSION = "0.0.33"
 end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.28"
+  VERSION = "0.0.29"
 end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -82,6 +82,25 @@ describe Ttdrest::Client do
       let(:regency_exclusion_window_in_minutes) { 2147483647 }
       let(:geo_segment_adjustments) { ['a','b','c'] }
       let(:data_element_adjustments) { ['d','e','f'] }
+      let(:associated_bid_lists) do
+        [
+          {
+            "BidListId": "abc123",
+            "IsEnabled": true,
+            "IsDefaultForDimension": false,
+          },
+          {
+            "BidListId": "def234",
+            "IsEnabled": true,
+            "IsDefaultForDimension": false,
+          },
+          {
+            "BidListId": "ghi345",
+            "IsEnabled": true,
+            "IsDefaultForDimension": false,
+          }
+        ]
+      end
 
       let(:params) do
         {
@@ -100,6 +119,7 @@ describe Ttdrest::Client do
           regency_exclusion_window_in_minutes: regency_exclusion_window_in_minutes,
           geo_segment_adjustments: geo_segment_adjustments,
           data_element_adjustments: data_element_adjustments,
+          associated_bid_lists: associated_bid_lists,
         }
       end
 
@@ -599,10 +619,27 @@ describe Ttdrest::Client do
             end
 
             it "no longer sends the classic-only audience attribute RecencyAdjustments" do
-                puts client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
               expect(
                 client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
               ).to_not include('RecencyAdjustments')
+            end
+
+            describe 'megagon only params' do
+              it 'determines the value of AssociatedBidLists' do
+                expect(
+                  client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['AssociatedBidLists']
+                ).to eq(associated_bid_lists)
+              end
+
+              context 'when nil' do
+                let(:associated_bid_lists) { nil }
+
+                it 'does not contain the key at all' do
+                  expect(
+                    client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+                  ).to_not include("AssociatedBidLists")
+                end
+              end
             end
           end
 
@@ -610,9 +647,9 @@ describe Ttdrest::Client do
             let(:is_classic) { 'false' }
 
             it 'sends IsClassic as true' do
-            expect(
-              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
-            ).to include('IsClassic' => true)
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+              ).to include('IsClassic' => true)
             end
           end
 
@@ -620,9 +657,9 @@ describe Ttdrest::Client do
             let(:is_classic) { Date.today }
 
             it 'sends IsClassic as true' do
-            expect(
-              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
-            ).to include('IsClassic' => true)
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+              ).to include('IsClassic' => true)
             end
           end
         end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -70,7 +70,7 @@ describe Ttdrest::Client do
         }
       end
       let(:site_quality_settings) { { 'aHashOfWayTooMuch': 'stuff' } }
-      let(:audience_id) { { "AudienceId": "ttdid123" } }
+      let(:audience_id) { "ttdid123" }
       let(:recency_adjustments) do
         [
           {
@@ -93,6 +93,7 @@ describe Ttdrest::Client do
           supply_vendors: supply_vendors,
           contract_targeting: contract_targeting,
           site_quality_settings: site_quality_settings,
+          audience_id: audience_id,
           recency_adjustments: recency_adjustments,
           regency_exclusion_window_in_minutes: regency_exclusion_window_in_minutes,
           geo_segment_adjustments: geo_segment_adjustments,
@@ -160,13 +161,13 @@ describe Ttdrest::Client do
             client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
           ).to include(
             "BudgetSettings" => 
-              {
-                "Budget": {  
-                  "Amount": 1000,
-                  "CurrencyCode": "USD"
-                }
+            {
+              "Budget": {  
+                "Amount": 1000,
+                "CurrencyCode": "USD"
               }
-            )
+            }
+          )
         end
 
         context 'when nil' do
@@ -186,11 +187,11 @@ describe Ttdrest::Client do
             client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
           ).to include(
             "BaseBidCPM" => 
-              {
-                "Amount": 1,
-                "CurrencyCode": "USD"
-              }
-            )
+            {
+              "Amount": 1,
+              "CurrencyCode": "USD"
+            }
+          )
         end
 
         context 'when nil' do
@@ -204,7 +205,49 @@ describe Ttdrest::Client do
         end
       end
 
-      describe 'params' do
+      describe 'max_bid_cpm' do
+        it 'determines the value of RTBAttributes["MaxBidCPM"]' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+          ).to include(
+            "MaxBidCPM" => 
+            {  
+              "Amount": 5,
+              "CurrencyCode": "USD"
+            }
+          )
+        end
+
+        context 'when nil' do
+          let(:max_bid_cpm) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+            ).to_not include("MaxBidCPM")
+          end
+        end
+      end
+
+      describe 'creative_ids' do
+        it 'determines the value of RTBAttributes["CreativeIds"]' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+          ).to include(
+            "CreativeIds" => [1,2,3] 
+          )
+        end
+        context 'when empty' do
+          let(:creative_ids) { [] }
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+            ).to_not include("CreativeIds")
+          end
+        end
+      end
+
+      describe 'params hash' do
         describe 'description' do
           it 'determines the value of Description' do
             expect(
@@ -259,6 +302,263 @@ describe Ttdrest::Client do
           end
         end
 
+        describe 'frequency_settings' do
+          it 'determines the value of RTBAttributes["FrequencySettings"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "FrequencySettings" => 
+              {  
+                "FrequencyCap": nil,
+                "FrequencyPeriodInMinutes": nil,
+                "FrequencyPricingSlopeCPM": {  
+                  "Amount": 0,
+                  "CurrencyCode": "USD"
+                }
+              }
+            )
+          end
+
+          context 'when nil' do
+            let(:frequency_settings) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("FrequencySettings")
+            end
+          end
+        end
+
+        describe 'site_targeting' do
+          it 'determines the value of RTBAttributes["SiteTargeting"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "SiteTargeting" => 
+              {
+                "SiteListIds": [],
+                "SiteListFallThroughAdjustment": 1
+              }
+            )
+          end
+
+          context 'when nil' do
+            let(:site_targeting) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("SiteTargeting")
+            end
+          end
+        end
+
+        describe 'fold_targeting' do
+          it 'determines the value of RTBAttributes["FoldTargeting"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "FoldTargeting" => 
+              {
+                "AboveFoldAdjustment": 1,
+                "BelowFoldAdjustment": 1,
+                "UnknownFoldAdjustment": 1
+              }
+            )
+          end
+
+          context 'when nil' do
+            let(:fold_targeting) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("FoldTargeting")
+            end
+          end
+        end
+
+        describe 'supply_vendors' do
+          it 'determines the value of RTBAttributes["SupplyVendorAdjustments"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "SupplyVendorAdjustments" => 
+              {
+                "DefaultAdjustment": 1,
+                "Adjustments": []
+              }
+            )
+          end
+
+          context 'when nil' do
+            let(:supply_vendors) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("SupplyVendorAdjustments")
+            end
+          end
+        end
+
+        describe 'contract_targeting' do
+          it 'determines the value of RTBAttributes["ContractTargeting"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "ContractTargeting" => 
+              {
+                "AllowOpenMarketBiddingWhenTargetingContracts": false,
+                "ContractIds": [],
+                "ContractGroupIds": []
+              }
+            )
+          end
+
+          context 'when nil' do
+            let(:contract_targeting) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("ContractTargeting")
+            end
+          end
+        end
+
+        describe 'site_quality_settings' do
+          it 'determines the value of RTBAttributes["SiteQualitySettings"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "SiteQualitySettings" => { 'aHashOfWayTooMuch': 'stuff' }
+            )
+          end
+
+          context 'when nil' do
+            let(:site_quality_settings) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("SiteQualitySettings")
+            end
+          end
+        end
+
+        context 'when audience_id is present' do
+          it 'determines the value of RTBAttributes["AudienceTargeting"]["AudienceId"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+            ).to include(
+              "AudienceId" => 'ttdid123'   
+            )
+          end
+
+          describe 'recency_adjustments' do
+            it 'determines the value of RTBAttributes["AudienceTargeting"]["RecencyAdjustments"]' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+              ).to include(
+                "RecencyAdjustments" => 
+                [
+                  {
+                    "RecencyExclusionWindowInMinutes": 0, "Adjustment": 1.0
+                  }
+                ]
+              )
+            end
+
+            context 'when nil' do
+              let(:recency_adjustments) { nil }
+
+              it 'a default RecencyAdjustments is set' do
+                expect(
+                  client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+                ).to include(
+                  "RecencyAdjustments" => 
+                  [
+                    {
+                      "RecencyWindowStartInMinutes"=> 0, "Adjustment" => 1.0
+                    }
+                  ]
+                )
+              end
+            end
+          end
+
+          describe 'regency_exclusion_window_in_minutes' do
+            it 'determines the value of RTBAttributes["AudienceTargeting"]["RecencyExclusionWindowInMinutes"]' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+              ).to include(
+                "RecencyExclusionWindowInMinutes" => 2147483647
+              )
+            end
+
+            context 'when nil' do
+              let(:regency_exclusion_window_in_minutes) { nil }
+
+              it 'a default RecencyAdjustments is set' do
+                expect(
+                  client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+                ).to include(
+                  "RecencyExclusionWindowInMinutes" => 129600
+                )
+              end
+            end
+          end
+        end
+        context 'when audience_id is not present' do
+          let(:audience_id) { nil }
+          it 'does not contain the Audience Targeting key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+            ).to_not include("AudienceTargeting")
+          end
+        end
+
+        describe 'geo_segment_adjustments' do
+          it 'determines the value of RTBAttributes["GeoSegmentAdjustments"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "GeoSegmentAdjustments" => ['a','b','c']
+            )
+          end
+
+          context 'when nil' do
+            let(:geo_segment_adjustments) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("GeoSegmentAdjustments")
+            end
+          end
+        end
+
+        describe 'data_element_adjustments' do
+          it 'determines the value of RTBAttributes["DataElementAdjustments"]' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+            ).to include(
+              "DataElementAdjustments" => ['d','e','f']
+            )
+          end
+
+          context 'when nil' do
+            let(:data_element_adjustments) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+              ).to_not include("DataElementAdjustments")
+            end
+          end
+        end
       end
     end
   end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -127,6 +127,12 @@ describe Ttdrest::Client do
         ]
       end
 
+      let(:quality_alliance_viewability_targeting) do
+        {
+          "QualityAllianceViewabilityEnabledState": "Disabled"
+        }
+      end
+
       let(:params) do
         {
           description: description,
@@ -146,6 +152,7 @@ describe Ttdrest::Client do
           data_element_adjustments: data_element_adjustments,
           associated_bid_lists: associated_bid_lists,
           new_bid_lists: new_bid_lists,
+          quality_alliance_viewability_targeting: quality_alliance_viewability_targeting,
         }
       end
 
@@ -685,7 +692,24 @@ describe Ttdrest::Client do
                     ).to_not include("NewBidLists")
                   end
                 end
+              end
 
+              context 'quality_alliance_viewability_targeting' do
+                it 'determines the value of QualityAllianceViewabilityTargeting' do
+                  expect(
+                    client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['QualityAllianceViewabilityTargeting']
+                  ).to eq(quality_alliance_viewability_targeting)
+                end
+
+                context 'when nil' do
+                  let(:quality_alliance_viewability_targeting) { nil }
+
+                  it 'does not contain the key at all' do
+                    expect(
+                      client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+                    ).to_not include("QualityAllianceViewabilityTargeting")
+                  end
+                end
               end
             end
           end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -1,0 +1,266 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe "with initialized client" do
+    let(:client) { Ttdrest::Client.new }
+
+    describe "#build_ad_group_data" do
+      let(:ad_group_id) { 'njutzfg' }
+      let(:campaign_id) { 'SampleCampaign' }
+      let(:name)        { 'Test AdGroup' }
+      let(:budget_settings) do
+        {
+          "Budget": {  
+            "Amount": 1000,
+            "CurrencyCode": "USD"
+          }
+        }
+      end
+      let(:base_bid_cpm) do
+        {
+          "Amount": 1,
+          "CurrencyCode": "USD"
+        }
+      end
+      let(:max_bid_cpm) do
+        {  
+          "Amount": 5,
+          "CurrencyCode": "USD"
+        }
+      end
+
+      let(:creative_ids) { [1,2,3] }
+      let(:description) { 'foo' }
+      let(:is_enabled) { true }
+      let(:industry_category_id) { 54 }
+      let(:frequency_settings) do
+        {  
+          "FrequencyCap": nil,
+          "FrequencyPeriodInMinutes": nil,
+          "FrequencyPricingSlopeCPM": {  
+            "Amount": 0,
+            "CurrencyCode": "USD"
+          }
+        }
+      end
+      let(:site_targeting) do
+        {
+          "SiteListIds": [],
+          "SiteListFallThroughAdjustment": 1
+        }
+      end
+      let(:fold_targeting) do
+        {
+          "AboveFoldAdjustment": 1,
+          "BelowFoldAdjustment": 1,
+          "UnknownFoldAdjustment": 1
+        }
+      end
+      let(:supply_vendors) do
+        {
+          "DefaultAdjustment": 1,
+          "Adjustments": []
+        }
+      end
+      let(:contract_targeting) do
+        {
+          "AllowOpenMarketBiddingWhenTargetingContracts": false,
+          "ContractIds": [],
+          "ContractGroupIds": []
+        }
+      end
+      let(:site_quality_settings) { { 'aHashOfWayTooMuch': 'stuff' } }
+      let(:audience_id) { { "AudienceId": "ttdid123" } }
+      let(:recency_adjustments) do
+        [
+          {
+            "RecencyExclusionWindowInMinutes": 0, "Adjustment": 1.0
+          }
+        ]
+      end
+      let(:regency_exclusion_window_in_minutes) { 2147483647 }
+      let(:geo_segment_adjustments) { ['a','b','c'] }
+      let(:data_element_adjustments) { ['d','e','f'] }
+
+      let(:params) do
+        {
+          description: description,
+          is_enabled: is_enabled,
+          industry_category_id: industry_category_id,
+          frequency_settings: frequency_settings,
+          site_targeting: site_targeting,
+          fold_targeting: fold_targeting,
+          supply_vendors: supply_vendors,
+          contract_targeting: contract_targeting,
+          site_quality_settings: site_quality_settings,
+          recency_adjustments: recency_adjustments,
+          regency_exclusion_window_in_minutes: regency_exclusion_window_in_minutes,
+          geo_segment_adjustments: geo_segment_adjustments,
+          data_element_adjustments: data_element_adjustments,
+        }
+      end
+
+      describe 'ad_group_id' do
+        it 'determines the value of AdGroupId' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+          ).to include({ "AdGroupId" => 'njutzfg' })
+        end
+
+        context 'when nil' do
+          let(:ad_group_id) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+            ).to_not include("AdGroupId")
+          end
+        end
+      end
+
+      describe 'campaign_id' do
+        it 'determines the value of CampaignId' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+          ).to include({ "CampaignId" => 'SampleCampaign' })
+        end
+
+        context 'when nil' do
+          let(:campaign_id) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+            ).to_not include("CampaignId")
+          end
+        end
+      end
+
+      describe 'name' do
+        it 'determines the value of AdGroupName' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+          ).to include({ "AdGroupName" => 'Test AdGroup' })
+        end
+
+        context 'when nil' do
+          let(:name) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+            ).to_not include("AdGroupName")
+          end
+        end
+      end
+
+      describe 'budget_settings' do
+        it 'determines the value of RTBAttributes["BudgetSettings"]' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+          ).to include(
+            "BudgetSettings" => 
+              {
+                "Budget": {  
+                  "Amount": 1000,
+                  "CurrencyCode": "USD"
+                }
+              }
+            )
+        end
+
+        context 'when nil' do
+          let(:budget_settings) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+            ).to_not include("BudgetSettings")
+          end
+        end
+      end
+
+      describe 'base_bid_cpm' do
+        it 'determines the value of RTBAttributes["BaseBidCPM"]' do
+          expect(
+            client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+          ).to include(
+            "BaseBidCPM" => 
+              {
+                "Amount": 1,
+                "CurrencyCode": "USD"
+              }
+            )
+        end
+
+        context 'when nil' do
+          let(:base_bid_cpm) { nil }
+
+          it 'does not contain the key at all' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
+            ).to_not include("BaseBidCPM")
+          end
+        end
+      end
+
+      describe 'params' do
+        describe 'description' do
+          it 'determines the value of Description' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include({ "Description" => 'foo' })
+          end
+
+          context 'when nil' do
+            let(:description) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+              ).to_not include("Description")
+            end
+          end
+        end
+
+        describe 'is_enabled' do
+          it 'determines the value of IsEnabled' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include({ "IsEnabled" => true })
+          end
+
+          context 'when nil' do
+            let(:is_enabled) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+              ).to_not include("IsEnabled")
+            end
+          end
+        end
+
+        describe 'industry_category_id' do
+          it 'determines the value of IndustryCategoryId' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include({ "IndustryCategoryId" => 54 })
+          end
+
+          context 'when nil' do
+            let(:industry_category_id) { nil }
+
+            it 'does not contain the key at all' do
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+              ).to_not include("IndustryCategoryId")
+            end
+          end
+        end
+
+      end
+    end
+  end
+end
+

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -573,9 +573,9 @@ describe Ttdrest::Client do
             let(:is_classic) { nil }
 
             it 'defaults to true, which is legacy functionality' do
-            expect(
-              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
-            ).to include('IsClassic' => true)
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+              ).to include('IsClassic' => true)
             end
           end
 
@@ -583,9 +583,26 @@ describe Ttdrest::Client do
             let(:is_classic) { false }
 
             it 'sends IsClassic as false' do
-            expect(
-              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
-            ).to include('IsClassic' => false)
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+              ).to include('IsClassic' => false)
+            end
+
+            %w(FrequencySettings SiteTargeting FoldTargeting
+            SupplyVendorAdjustments ContractTargeting SiteQualitySettings
+            GeoSegmentAdjustments DataElementAdjustments).each do |legacy_rtb_attribute|
+              it "no longer sends the classic-only rtb attribute #{legacy_rtb_attribute}" do
+                expect(
+                  client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']
+                ).to_not include(legacy_rtb_attribute)
+              end
+            end
+
+            it "no longer sends the classic-only audience attribute RecencyAdjustments" do
+                puts client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+              expect(
+                client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes']['AudienceTargeting']
+              ).to_not include('RecencyAdjustments')
             end
           end
 

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -8,6 +8,7 @@ describe Ttdrest::Client do
       let(:ad_group_id) { 'njutzfg' }
       let(:campaign_id) { 'SampleCampaign' }
       let(:name)        { 'Test AdGroup' }
+      let(:is_classic) { true }
       let(:budget_settings) do
         {
           "Budget": {  
@@ -86,6 +87,7 @@ describe Ttdrest::Client do
         {
           description: description,
           is_enabled: is_enabled,
+          is_classic: is_classic,
           industry_category_id: industry_category_id,
           frequency_settings: frequency_settings,
           site_targeting: site_targeting,
@@ -556,6 +558,34 @@ describe Ttdrest::Client do
               expect(
                 client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['RTBAttributes'].keys
               ).to_not include("DataElementAdjustments")
+            end
+          end
+        end
+
+        describe 'is_classic' do
+          it 'determines the value of IsClassic' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include('IsClassic' => true)
+          end
+
+          context 'when nil' do
+            let(:is_classic) { nil }
+
+            it 'defaults to true, which is legacy functionality' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include('IsClassic' => true)
+            end
+          end
+
+          context 'when false' do
+            let(:is_classic) { false }
+
+            it 'sends IsClassic as false' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include('IsClassic' => false)
             end
           end
         end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -102,6 +102,31 @@ describe Ttdrest::Client do
         ]
       end
 
+      let(:new_bid_lists) do
+        [
+          {
+            "Name": "Foo Bid List",
+            "BidListAdjustmentType": "TargetList",
+            "IsEnabled": true,
+            "IsDefaultForDimension": false,
+            "BidLines": [
+              { "DoubleVerifyBotAvoidanceCategoryId": "sample string 1" }
+            ],
+          },
+          {
+            "Name": "Bar Bid List",
+            "BidListAdjustmentType": "BlockList",
+            "IsEnabled": true,
+            "IsDefaultForDimension": false,
+            "BidLines": [
+              { "Os": "WindowsPhoneAll" },
+              { "Os": "iOSAll" },
+              { "Os": "AndroidAll" },
+            ],
+          },
+        ]
+      end
+
       let(:params) do
         {
           description: description,
@@ -120,6 +145,7 @@ describe Ttdrest::Client do
           geo_segment_adjustments: geo_segment_adjustments,
           data_element_adjustments: data_element_adjustments,
           associated_bid_lists: associated_bid_lists,
+          new_bid_lists: new_bid_lists,
         }
       end
 
@@ -625,20 +651,41 @@ describe Ttdrest::Client do
             end
 
             describe 'megagon only params' do
-              it 'determines the value of AssociatedBidLists' do
-                expect(
-                  client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['AssociatedBidLists']
-                ).to eq(associated_bid_lists)
+              context 'associated_bid_lists' do
+                it 'determines the value of AssociatedBidLists' do
+                  expect(
+                    client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['AssociatedBidLists']
+                  ).to eq(associated_bid_lists)
+                end
+
+                context 'when nil' do
+                  let(:associated_bid_lists) { nil }
+
+                  it 'does not contain the key at all' do
+                    expect(
+                      client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+                    ).to_not include("AssociatedBidLists")
+                  end
+                end
               end
 
-              context 'when nil' do
-                let(:associated_bid_lists) { nil }
-
-                it 'does not contain the key at all' do
+              context 'new_bid_lists' do
+                it 'determines the value of NewBidLists' do
                   expect(
-                    client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
-                  ).to_not include("AssociatedBidLists")
+                    client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)['NewBidLists']
+                  ).to eq(new_bid_lists)
                 end
+
+                context 'when nil' do
+                  let(:new_bid_lists) { nil }
+
+                  it 'does not contain the key at all' do
+                    expect(
+                      client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params).keys
+                    ).to_not include("NewBidLists")
+                  end
+                end
+
               end
             end
           end

--- a/spec/ttdrest/concerns/ad_group_spec.rb
+++ b/spec/ttdrest/concerns/ad_group_spec.rb
@@ -588,6 +588,26 @@ describe Ttdrest::Client do
             ).to include('IsClassic' => false)
             end
           end
+
+          context 'when stringy' do
+            let(:is_classic) { 'false' }
+
+            it 'sends IsClassic as true' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include('IsClassic' => true)
+            end
+          end
+
+          context 'when non boolean object' do
+            let(:is_classic) { Date.today }
+
+            it 'sends IsClassic as true' do
+            expect(
+              client.build_ad_group_data(ad_group_id, campaign_id, name, budget_settings, base_bid_cpm, max_bid_cpm, creative_ids, params)
+            ).to include('IsClassic' => true)
+            end
+          end
         end
       end
     end

--- a/spec/ttdrest/concerns/additional_fees_spec.rb
+++ b/spec/ttdrest/concerns/additional_fees_spec.rb
@@ -1,0 +1,126 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require 'pry'
+
+describe Ttdrest::Client do
+  describe "with initialized client" do
+    let(:client) { Ttdrest::Client.new }
+
+    let(:owner_id) { 1 }
+    let(:owner_type) { 'campaign' }
+    let(:start_date) { Time.now }
+    let(:fee_1) do
+      {
+        description: 'Foo Fee',
+        amount: 678,
+        fee_type: 'FeeCPM',
+      }
+    end
+    let(:fee_2) do
+      {
+        description: 'Bar Fee',
+        amount: 404,
+        fee_type: 'PartnerCostPercentage',
+      }
+    end
+    let(:fees) { [fee_1, fee_2] }
+
+    let(:additional_fees_body_response) { { 'Foo' => 'bar' } }
+
+    describe '#get_additional_fees' do
+      it 'builds the path with the given id and type' do
+        expect(client).to receive(:get).with('/additionalfees/campaign/1', {})
+        client.get_additional_fees(owner_id, owner_type)
+      end
+    end
+
+    describe '#create_additional_fees' do
+      it 'builds the additional fees body and submits it to the create api' do
+        # We test building the body, so just make sure we use it and it's converted to json
+        expect(client).to receive(:additional_fees_body).and_return(additional_fees_body_response)
+        expect(client).to receive(:data_post).with('/additionalfees', 'application/json', "{\"Foo\":\"bar\"}")
+        client.create_additional_fees(owner_id,owner_type,start_date,fees)
+      end
+    end
+
+    describe '#update_additional_fees' do
+      it 'builds the additional fees body and submits it to the create api' do
+        # We test building the body, so just make sure we use it and it's converted to json
+        expect(client).to receive(:additional_fees_body).and_return(additional_fees_body_response)
+        expect(client).to receive(:data_put).with('/additionalfees', 'application/json', "{\"Foo\":\"bar\"}")
+        client.update_additional_fees(owner_id,owner_type,start_date,fees)
+      end
+    end
+
+    describe "#additional_fees_body" do
+      it 'builds and populates the StartDateUtc attribute with iso8601 format' do
+        expect(
+          client.additional_fees_body(owner_id, owner_type, start_date, fees)
+        ).to include({ "StartDateUtc" => start_date.utc.strftime("%Y-%m-%dT%H:%M:%SZ") })
+      end
+
+      it 'builds OwnerId attribute' do
+        expect(
+          client.additional_fees_body(owner_id, owner_type, start_date, fees)
+        ).to include({ 'OwnerId' => owner_id })
+      end
+
+      it 'builds OwnerType attribute' do
+        expect(
+          client.additional_fees_body(owner_id, owner_type, start_date, fees)
+        ).to include({ 'OwnerType' => owner_type })
+      end
+
+      it 'builds Fees attribute using each fee provided' do
+        expect(
+          client.additional_fees_body(owner_id, owner_type, start_date, fees)['Fees']
+        ).to include({ 
+          'Description' => fee_1[:description],
+          'Amount' => fee_1[:amount],
+          'FeeType' => fee_1[:fee_type]
+        })
+        expect(
+          client.additional_fees_body(owner_id, owner_type, start_date, fees)['Fees']
+        ).to include({ 
+          'Description' => fee_2[:description],
+          'Amount' => fee_2[:amount],
+          'FeeType' => fee_2[:fee_type]
+        })
+      end
+
+      context 'with raw JSON fees' do
+        let(:fee_1) do
+          {
+            'Description' => 'Foo Fee',
+            'Amount' => 678,
+            'FeeType' => 'FeeCPM',
+          }
+        end
+        let(:fee_2) do
+          {
+            'Description' => 'Bar Fee',
+            'Amount' => 404,
+            'FeeType' => 'PartnerCostPercentage',
+          }
+        end
+
+        it 'builds Fees attribute using each fee provided' do
+          expect(
+            client.additional_fees_body(owner_id, owner_type, start_date, fees)['Fees']
+          ).to include({ 
+            'Description' => fee_1['Description'],
+            'Amount' => fee_1['Amount'],
+            'FeeType' => fee_1['FeeType']
+          })
+          expect(
+            client.additional_fees_body(owner_id, owner_type, start_date, fees)['Fees']
+          ).to include({ 
+            'Description' => fee_2['Description'],
+            'Amount' => fee_2['Amount'],
+            'FeeType' => fee_2['FeeType']
+          })
+        end
+      end
+    end
+  end
+end
+

--- a/spec/ttdrest/concerns/base_spec.rb
+++ b/spec/ttdrest/concerns/base_spec.rb
@@ -1,0 +1,106 @@
+require 'time'
+require 'spec_helper'
+
+RSpec.describe 'Base Concern' do
+  let(:client) { Ttdrest::Client.new }
+
+  let(:faux_response) { Struct.new(:code, keyword_init: true) }
+
+  describe 'parse_header_retry' do
+    it 'returns nil if the objects lacks Retry-After' do
+      expect(client.parse_header_retry({})).to be_nil
+    end
+
+    it 'parses numeric waits' do
+      expect(client.parse_header_retry({'Retry-After' => '1234'})).to eq 1234
+    end
+
+    it 'parses date strings' do
+      date = Time.now + 60
+
+      expect(
+        client.parse_header_retry({'Retry-After' => date.rfc2822})
+      ).to be_within(1).of(60)
+    end
+
+    it 'returns nil for invalid dates' do
+      date_string = 'Wed, 41 Oct 3015 07:28:00 GMT'
+
+      expect(
+        client.parse_header_retry({'Retry-After' => date_string})
+      ).to be_nil
+    end
+
+    it 'returns nil if the date is in the past' do
+      date_string = (Time.now - 60).rfc2822
+
+      expect(
+        client.parse_header_retry({'Retry-After' => date_string})
+      ).to be_nil
+    end
+
+    it 'returns a maximum of 120seconds' do
+      date_string = (Time.now + 200).rfc2822
+
+      expect(
+        client.parse_header_retry({'Retry-After' => date_string})
+      ).to eq 120
+    end
+  end
+
+  describe '#retryable_http_error?' do
+    it 'is false when passed nil' do
+      expect(client.retryable_http_error?(nil)).to be_falsy
+    end
+
+    it 'is true when the http code is 429' do
+      expect(client.retryable_http_error?(faux_response.new(code: 429))).to be_truthy
+    end
+
+    it 'is true when in the 500 range' do
+      expect(client.retryable_http_error?(faux_response.new(code: 501))).to be_truthy
+    end
+
+    it 'is false when the http code is 404' do
+      expect(client.retryable_http_error?(faux_response.new(code: 404))).to be_falsy
+    end
+  end
+
+  describe '#perform_request' do
+    let(:connection) { double() }
+    let(:request) { double() }
+    let(:code) { 200 }
+
+    before do
+      allow(connection).to receive(:request).and_return(faux_response.new(code: code))
+      allow(client).to receive(:sleep)
+    end
+
+    it 'backs off 3 times with jitter' do
+      allow(connection).to receive(:request).and_raise(Ttdrest::RecoverableHttpError.new)
+      expect(client).to receive(:sleep).with(be_within(0.375).of(1.25 ** 1))
+      expect(client).to receive(:sleep).with(be_within(0.469).of(1.25 ** 2))
+      expect(client).to receive(:sleep).with(be_within(0.586).of(1.25 ** 3))
+
+      expect(connection).to receive(:request).with(request).exactly(4).times
+
+      expect { client.perform_request(request, connection) }.to raise_error(Ttdrest::RecoverableHttpError)
+    end
+
+    it 'respects the retry-after time if detected' do
+      allow(connection).to receive(:request).and_raise(Ttdrest::RecoverableHttpError.new)
+      allow(client).to receive(:parse_header_retry).and_return(12)
+      expect(client).to receive(:sleep).with(12).exactly(3).times
+
+      expect { client.perform_request(request, connection) }.to raise_error(Ttdrest::RecoverableHttpError)
+    end
+
+    it 'returns the response when successful' do
+      response = faux_response.new(code: 200)
+
+      expect(connection).to receive(:request).with(request).and_return(response)
+      expect(client.perform_request(request, connection)).to eq response
+    end
+  end
+
+end

--- a/spec/ttdrest/concerns/base_spec.rb
+++ b/spec/ttdrest/concerns/base_spec.rb
@@ -54,15 +54,15 @@ RSpec.describe 'Base Concern' do
     end
 
     it 'is true when the http code is 429' do
-      expect(client.retryable_http_error?(faux_response.new(code: 429))).to be_truthy
+      expect(client.retryable_http_error?(faux_response.new(code: '429'))).to be_truthy
     end
 
     it 'is true when in the 500 range' do
-      expect(client.retryable_http_error?(faux_response.new(code: 501))).to be_truthy
+      expect(client.retryable_http_error?(faux_response.new(code: '501'))).to be_truthy
     end
 
     it 'is false when the http code is 404' do
-      expect(client.retryable_http_error?(faux_response.new(code: 404))).to be_falsy
+      expect(client.retryable_http_error?(faux_response.new(code: '404'))).to be_falsy
     end
   end
 
@@ -96,7 +96,7 @@ RSpec.describe 'Base Concern' do
     end
 
     it 'returns the response when successful' do
-      response = faux_response.new(code: 200)
+      response = faux_response.new(code: '200')
 
       expect(connection).to receive(:request).with(request).and_return(response)
       expect(client.perform_request(request, connection)).to eq response

--- a/spec/ttdrest/concerns/campaign_flight_spec.rb
+++ b/spec/ttdrest/concerns/campaign_flight_spec.rb
@@ -17,21 +17,66 @@ describe Ttdrest::Client do
           'DailyTargetInAdvertiserCurrency' => daily_budget,
           'CampaignId' => campaign_id,
           'CampaignFlightId' => campaign_flight_id,
+          'EndDateExclusiveUTC' => end_date,
           'StartDateInclusiveUTC' => start_date,
-          'EndDateExclusiveUTC' => end_date
         }
       }
       context "update" do
-        it 'sets EndDate to nil when end_date is nil' do
-          expect(client).to receive(:data_put).with("/campaignflight", "application/json", flight_data.to_json)
-          client.update_campaign_flight(
-            campaign_id: campaign_id,
-            campaign_flight_id: campaign_flight_id,
-            budget: budget,
-            daily_budget: daily_budget,
-            start_date: start_date,
-            end_date: end_date
-          )
+        describe "when campaign_id is NOT present" do
+          it 'does not make api call' do
+            expect(client).to_not receive(:data_put)
+            client.update_campaign_flight(
+              campaign_id: nil,
+              campaign_flight_id: campaign_flight_id,
+              budget: budget,
+              daily_budget: daily_budget,
+              start_date: start_date,
+              end_date: end_date,
+            )
+          end
+        end
+
+        describe "when campaign_flight_id is NOT present" do
+          it 'does not make api call' do
+            expect(client).to_not receive(:data_put)
+            client.update_campaign_flight(
+              campaign_id: campaign_id,
+              campaign_flight_id: nil,
+              budget: budget,
+              daily_budget: daily_budget,
+              start_date: start_date,
+              end_date: end_date,
+            )
+          end
+        end
+
+        describe "when campaign_id and campaign_flight_id are present" do
+          it 'sends correct information' do
+            expect(client).to receive(:data_put).with("/campaignflight", "application/json", flight_data.to_json)
+            client.update_campaign_flight(
+              campaign_id: campaign_id,
+              campaign_flight_id: campaign_flight_id,
+              budget: budget,
+              daily_budget: daily_budget,
+              start_date: start_date,
+              end_date: end_date,
+            )
+          end
+
+          describe "when start date is nil" do
+            it 'does not send start date if start date nil' do
+              flight_data.delete("StartDateInclusiveUTC")
+              expect(client).to receive(:data_put).with("/campaignflight", "application/json", flight_data.to_json)
+              client.update_campaign_flight(
+                campaign_id: campaign_id,
+                campaign_flight_id: campaign_flight_id,
+                budget: budget,
+                daily_budget: daily_budget,
+                start_date: nil,
+                end_date: end_date,
+              )
+            end
+          end
         end
       end
     end

--- a/spec/ttdrest/concerns/campaign_flight_spec.rb
+++ b/spec/ttdrest/concerns/campaign_flight_spec.rb
@@ -24,7 +24,14 @@ describe Ttdrest::Client do
       context "update" do
         it 'sets EndDate to nil when end_date is nil' do
           expect(client).to receive(:data_put).with("/campaignflight", "application/json", flight_data.to_json)
-          client.update_campaign_flight(campaign_id, campaign_flight_id, budget, daily_budget, start_date, end_date)
+          client.update_campaign_flight(
+            campaign_id: campaign_id,
+            campaign_flight_id: campaign_flight_id,
+            budget: budget,
+            daily_budget: daily_budget,
+            start_date: start_date,
+            end_date: end_date
+          )
         end
       end
     end

--- a/spec/ttdrest/concerns/campaign_flight_spec.rb
+++ b/spec/ttdrest/concerns/campaign_flight_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe "with initialized client" do
+    let!(:client) { Ttdrest::Client.new }
+
+    describe "#update_campaign_flight" do
+      let(:campaign_id)         { '1testid' }
+      let(:campaign_flight_id)  { 1 }
+      let(:budget)              { 10 }
+      let(:daily_budget)        { 1 }
+      let(:start_date)          { 30.days.ago }
+      let(:end_date)            { 30.days.from_now }
+      let(:flight_data) {
+        {
+          'BudgetInAdvertiserCurrency' => budget,
+          'DailyTargetInAdvertiserCurrency' => daily_budget,
+          'CampaignId' => campaign_id,
+          'CampaignFlightId' => campaign_flight_id,
+          'StartDateInclusiveUTC' => start_date,
+          'EndDateExclusiveUTC' => end_date
+        }
+      }
+      context "update" do
+        it 'sets EndDate to nil when end_date is nil' do
+          expect(client).to receive(:data_put).with("/campaignflight", "application/json", flight_data.to_json)
+          client.update_campaign_flight(campaign_id, campaign_flight_id, budget, daily_budget, start_date, end_date)
+        end
+      end
+    end
+  end
+end

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -10,31 +10,6 @@ describe Ttdrest::Client do
       let(:budget)      { 1.01 }
       let(:start_date)  { Date.today }
 
-      describe "campaign_flights" do
-        let(:dtiac) {
-          [ {
-            'CampaignId' => 1,
-            'CampaignFlightId' => 1,
-            'StartDateInclusiveUTC' => start_date,
-            'EndDateExclusiveUTC' => 1.month.from_now,
-            'BudgetInAdvertiserCurrency' => 'USD',
-            'DailyTargetInAdvertiserCurrency' => budget
-          }]
-        }
-        it "set CampaignFlights" do
-
-          expect(
-            client.build_campaign_data(campaign_id, name, budget, start_date, [], { campaign_flights: dtiac })
-          ).to include({ "CampaignFlights" => dtiac })
-        end
-
-        it "does not set CampaignFlights when campaign_flights does not exist" do
-          expect(
-            client.build_campaign_data(campaign_id, name, budget, start_date, [], {})
-          ).to_not include({ "CampaignFlights" => dtiac })
-        end
-      end
-
       context "EndDate" do
         it 'sets EndDate to nil when end_date is nil' do
           expect(

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -30,6 +30,100 @@ describe Ttdrest::Client do
           ).to_not include("EndDate")
         end
       end
+
+      context 'Fees' do
+        let(:partner_cost_percentage_fee) { 1 }
+
+        let(:partner_cpm_fee) do
+          {
+            'Amount' => 0.01,
+            'CurrencyCode' => 'USD',
+          }
+        end
+
+        let(:partner_cpc_fee) do
+          {
+            'Amount' => 0.02,
+            'CurrencyCode' => 'USD',
+          }
+        end
+
+        let(:params) do
+          {
+            partner_cost_percentage_fee: partner_cost_percentage_fee,
+            partner_cpm_fee: partner_cpm_fee,
+            partner_cpc_fee: partner_cpc_fee,
+          }
+        end
+
+        it 'populates PartnerCostPercentageFee' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], params)
+          ).to include({ "PartnerCostPercentageFee" => partner_cost_percentage_fee })
+        end
+
+        it 'populates PartnerCPMFee' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], params)
+          ).to include({ "PartnerCPMFee" => partner_cpm_fee})
+        end
+
+        it 'populates PartnerCPCFee' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], params)
+          ).to include({ "PartnerCPCFee" => partner_cpc_fee})
+        end
+
+        context 'when additional_fee_card is present' do
+          let(:additional_fee_card) do
+            {
+              "StartDateUtc" => "2020-04-15T21:15:49.0540308+00:00",
+              "Fees" => [
+                {
+                  "Description" => "sample string 1",
+                  "Amount" => 2,
+                  "FeeType" => "MediaCostPercentage"
+                },
+                {
+                  "Description" => "sample string 1",
+                  "Amount" => 2,
+                  "FeeType" => "MediaCostPercentage"
+                },
+                {
+                  "Description" => "sample string 1",
+                  "Amount" => 2,
+                  "FeeType" => "MediaCostPercentage"
+                }
+              ],
+              "OwnerId" => "sample string 2",
+              "OwnerType" => "sample string 3"
+            }
+          end
+
+          let(:params) do
+            {
+              additional_fee_card: additional_fee_card,
+            }
+          end
+
+          context 'when campaign_id is present' do
+            # this attribute is only available on create, not update
+            it 'does not send AdditionalFeeCardOnCreate' do
+              expect(
+                client.build_campaign_data(campaign_id, name, budget, start_date, [], params).keys
+              ).to_not include("AdditionalFeeCardOnCreate")
+            end
+          end
+
+          context 'when campaign_id is not present' do
+            it 'populates AdditionalFeeCardOnCreate' do
+              expect(
+                client.build_campaign_data(nil, name, budget, start_date, [], params)
+              ).to include({ "AdditionalFeeCardOnCreate" => additional_fee_card})
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -13,10 +13,13 @@ describe Ttdrest::Client do
       describe "campaign_flights" do
         it "set CampaignFlights" do
           dtiac = [ {
-            'StartDateInclusiveUTC' => ad_campaign.start_at,
+            'CampaignId' => 1,
+            'CampaignFlightId' => 1,
+            'StartDateInclusiveUTC' => start_date,
+            'EndDateExclusiveUTC' => 1.month.from_now,
             'BudgetInAdvertiserCurrency' => 'USD',
-            'DailyTargetInAdvertiserCurrency' => ad_campaign.ad_group.daily_budget
-          ]
+            'DailyTargetInAdvertiserCurrency' => budget
+          }]
           expect(
             client.build_campaign_data(campaign_id, name, budget, start_date, [], { campaign_flights: dtiac })
           ).to include({ "CampaignFlights" => dtiac })

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -10,6 +10,19 @@ describe Ttdrest::Client do
       let(:budget)      { 1.01 }
       let(:start_date)  { Date.today }
 
+      describe "campaign_flights" do
+        it "set CampaignFlights" do
+          dtiac = [ {
+            'StartDateInclusiveUTC' => ad_campaign.start_at,
+            'BudgetInAdvertiserCurrency' => 'USD',
+            'DailyTargetInAdvertiserCurrency' => ad_campaign.ad_group.daily_budget
+          ]
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { campaign_flights: dtiac })
+          ).to include({ "CampaignFlights" => dtiac })
+        end
+      end
+
       context "EndDate" do
         it 'sets EndDate to nil when end_date is nil' do
           expect(

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -1,0 +1,35 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe "with initialized client" do
+    let(:client) { Ttdrest::Client.new }
+
+    describe "#build_campaign_data" do
+      let(:campaign_id) { 1 }
+      let(:name)        { 'My Campaign Name' }
+      let(:budget)      { 1.01 }
+      let(:start_date)  { Date.today }
+
+      context "EndDate" do
+        it 'sets EndDate to nil when end_date is nil' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: nil })
+          ).to include({ "EndDate" => nil })
+        end
+
+        it 'includes a formatted EndDate when a end_date is sent' do
+          end_date = Date.today
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: end_date })
+          ).to include({ "EndDate" => end_date.strftime("%Y-%m-%dT%H:%M:%SZ") })
+        end
+
+        it 'does not include EndDate when no date is sent' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { })
+          ).to_not include("EndDate")
+        end
+      end
+    end
+  end
+end

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -11,8 +11,8 @@ describe Ttdrest::Client do
       let(:start_date)  { Date.today }
 
       describe "campaign_flights" do
-        it "set CampaignFlights" do
-          dtiac = [ {
+        let(:dtiac) {
+          [ {
             'CampaignId' => 1,
             'CampaignFlightId' => 1,
             'StartDateInclusiveUTC' => start_date,
@@ -20,9 +20,18 @@ describe Ttdrest::Client do
             'BudgetInAdvertiserCurrency' => 'USD',
             'DailyTargetInAdvertiserCurrency' => budget
           }]
+        }
+        it "set CampaignFlights" do
+
           expect(
             client.build_campaign_data(campaign_id, name, budget, start_date, [], { campaign_flights: dtiac })
           ).to include({ "CampaignFlights" => dtiac })
+        end
+
+        it "does not set CampaignFlights when campaign_flights does not exist" do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], {})
+          ).to_not include({ "CampaignFlights" => dtiac })
         end
       end
 

--- a/spec/ttdrest/concerns/hd_reports_spec.rb
+++ b/spec/ttdrest/concerns/hd_reports_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe 'with initialized client' do
+    let(:client) { Ttdrest::Client.new }
+
+    describe '#get_hd_reports' do
+      xit 'fetches reports' do
+        VCR.use_cassette('get_reports') do
+          expect(client.get_reports()).to be nil
+        end
+      end
+
+      context "with report date" do
+        let(:report_date) { Date.today }
+
+        it 'fetches reports for a date' do
+          VCR.use_cassette('get_reports_with_date') do
+            expect(client.get_reports(report_date)).to be nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ttdrest/concerns/my_reports_spec.rb
+++ b/spec/ttdrest/concerns/my_reports_spec.rb
@@ -1,0 +1,34 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe 'with initialized client' do
+    let(:client) { Ttdrest::Client.new }
+
+    describe '#get_my_reports' do
+      xit 'fetches reports' do
+        VCR.use_cassette('get_my_reports') do
+          expect(client.get_my_reports()).to be_nil
+        end
+      end
+
+      context "with report date" do
+        let(:report_date) { Date.today }
+
+        it 'fetches reports for a date' do
+          VCR.use_cassette('get_my_reports_with_date') do
+            expect(client.get_my_reports(report_date)).to be_nil
+          end
+        end
+
+        context 'with schedule name contains' do
+          let(:options) { { report_schedule_name_contains: 'Data Elements', } }
+          it 'fetches reports for a date' do
+            VCR.use_cassette('get_my_reports_with_date_and_schedule_name') do
+              expect(client.get_my_reports(report_date, options)).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ttdrest/concerns/my_reports_spec.rb
+++ b/spec/ttdrest/concerns/my_reports_spec.rb
@@ -16,7 +16,39 @@ describe Ttdrest::Client do
 
         it 'fetches reports for a date' do
           VCR.use_cassette('get_my_reports_with_date') do
+            expect(client).to receive(:data_post).with(
+              '/myreports/reportexecution/query/advertisers',
+              'application/json',
+              a_string_matching("\"ReportDateUTC\":\"#{report_date.to_date}")
+            )
             expect(client.get_my_reports(report_date)).to be_nil
+          end
+        end
+
+        context 'with an option based advertiser id' do
+          it 'fetches reports for a date' do
+            VCR.use_cassette('get_my_reports_with_date') do
+              expect(client).to receive(:data_post).with(
+                '/myreports/reportexecution/query/advertisers',
+                'application/json',
+                a_string_matching("\"AdvertiserIds\":[?\"advertiser_id\"]?")
+              )
+              expect(client.get_my_reports(report_date, { advertiser_id: "advertiser_id" })).to be_nil
+            end
+          end
+        end
+        context 'with a client based advertiser id' do
+          let(:client) { Ttdrest::Client.new(advertiser_id: "advertiser_id") }
+
+          it 'fetches reports for a date' do
+            VCR.use_cassette('get_my_reports_with_date') do
+              expect(client).to receive(:data_post).with(
+                '/myreports/reportexecution/query/advertisers',
+                'application/json',
+                a_string_matching("\"AdvertiserIds\":[?\"advertiser_id\"]?")
+              )
+              expect(client.get_my_reports(report_date)).to be_nil
+            end
           end
         end
 
@@ -24,6 +56,11 @@ describe Ttdrest::Client do
           let(:options) { { report_schedule_name_contains: 'Data Elements', } }
           it 'fetches reports for a date' do
             VCR.use_cassette('get_my_reports_with_date_and_schedule_name') do
+              expect(client).to receive(:data_post).with(
+                '/myreports/reportexecution/query/advertisers',
+                'application/json',
+                a_string_matching(/ReportScheduleNameContains/)
+              )
               expect(client.get_my_reports(report_date, options)).to be_nil
             end
           end

--- a/spec/vcr/get_hd_reports_with_date.yml
+++ b/spec/vcr/get_hd_reports_with_date.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://v3/creative/query/advertiser
+    uri: https:/v3/myreports/reportexecution/query/advertisers
     body:
       encoding: UTF-8
       string: '{"AdvertiserId":"advertiser_id","PageStartIndex":0,"PageSize":null}'
@@ -18,7 +18,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: ok
+      message: OK
     headers:
       Cache-Control:
       - no-cache

--- a/spec/vcr/get_my_reports_with_date.yml
+++ b/spec/vcr/get_my_reports_with_date.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://v3/creative/query/advertiser
+    uri: https:/v3/myreports/reportexecution/query/advertisers
     body:
       encoding: UTF-8
       string: '{"AdvertiserId":"advertiser_id","PageStartIndex":0,"PageSize":null}'
@@ -18,7 +18,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: ok
+      message: Ok
     headers:
       Cache-Control:
       - no-cache

--- a/spec/vcr/get_my_reports_with_date_and_schedule_name.yml
+++ b/spec/vcr/get_my_reports_with_date_and_schedule_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://v3/creative/query/advertiser
+    uri: https:/v3/myreports/reportexecution/query/advertisers
     body:
       encoding: UTF-8
       string: '{"AdvertiserId":"advertiser_id","PageStartIndex":0,"PageSize":null}'

--- a/ttdrest.gemspec
+++ b/ttdrest.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", "> 4.0.0 "
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "vcr"

--- a/ttdrest.gemspec
+++ b/ttdrest.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", "> 4.0.0 "
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
To support the follow requests, newly used fields need to be supported/passed through
     
https://terminusteam.slack.com/archives/C010EHQPMUP/p1593549241046700
